### PR TITLE
Fix thinking expand button glitch

### DIFF
--- a/app/(logged-in)/projects/[id]/components/chat/assistant-response.tsx
+++ b/app/(logged-in)/projects/[id]/components/chat/assistant-response.tsx
@@ -17,34 +17,44 @@ export default function AssistantResponse({
   response,
   className,
 }: AssistantResponseProps) {
-  const [collapsedBlocks, setCollapsedBlocks] = useState<Set<string>>(new Set());
+  // Track user's explicit choices for each block (blockId -> isCollapsed)
+  const [userChoices, setUserChoices] = useState<Map<string, boolean>>(new Map());
 
   const handleToggleCollapse = (blockId: string) => {
-    setCollapsedBlocks(prev => {
-      const newSet = new Set(prev);
-      if (newSet.has(blockId)) {
-        newSet.delete(blockId);
-      } else {
-        newSet.add(blockId);
-      }
-      return newSet;
+    setUserChoices(prev => {
+      const newMap = new Map(prev);
+      const currentBlock = response.contentBlocks.find(block => block.id === blockId);
+      const currentState = newMap.has(blockId) 
+        ? newMap.get(blockId)! 
+        : (currentBlock?.isCollapsed ?? false);
+      
+      // Toggle the current state
+      newMap.set(blockId, !currentState);
+      return newMap;
     });
   };
 
   return (
     <div className={cn('w-full space-y-3', className)}>
       {/* Content Blocks */}
-      {response.contentBlocks.map((block) => (
-        <ContentBlock
-          key={block.id}
-          contentBlock={{
-            ...block,
-            isCollapsed: collapsedBlocks.has(block.id) || block.isCollapsed,
-          }}
-          onToggleCollapse={handleToggleCollapse}
-          className="w-full"
-        />
-      ))}
+      {response.contentBlocks.map((block) => {
+        // If user has made an explicit choice, use that. Otherwise use original state.
+        const isCollapsed = userChoices.has(block.id) 
+          ? userChoices.get(block.id)!
+          : (block.isCollapsed ?? false);
+
+        return (
+          <ContentBlock
+            key={block.id}
+            contentBlock={{
+              ...block,
+              isCollapsed,
+            }}
+            onToggleCollapse={handleToggleCollapse}
+            className="w-full"
+          />
+        );
+      })}
 
       {/* Streaming indicator */}
       {response.status === 'streaming' && (


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Fixes the thinking expand button not working by improving state management for content block collapse.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The previous logic `collapsedBlocks.has(block.id) || block.isCollapsed` meant that once a block was auto-collapsed (setting `block.isCollapsed` to `true`), it could never be expanded by user interaction because the OR condition would always evaluate to `true`. This PR introduces a `Map` to explicitly track user-initiated collapse/expand choices, giving them precedence over the block's initial or auto-collapsed state.

---
<a href="https://cursor.com/background-agent?bcId=bc-d5872a13-c4b5-45ac-a49f-f766fc965d4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d5872a13-c4b5-45ac-a49f-f766fc965d4c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>