### PR TITLE
Fix @content-block.tsx streaming spacing inconsistency

### DIFF
--- a/app/(logged-in)/projects/[id]/components/chat/content-block.tsx
+++ b/app/(logged-in)/projects/[id]/components/chat/content-block.tsx
@@ -111,7 +111,7 @@ export default function ContentBlock({
             <div className="pl-2 py-2">
               <div className="text-muted-foreground/70 text-xs leading-relaxed">
                 {contentBlock.content.split('\n').map((line, j) => (
-                  <p key={j} className={line.trim() === '' ? 'h-3' : '[word-break:normal] [overflow-wrap:anywhere]'}>
+                  <p key={j} className={line.trim() === '' ? 'h-3 my-1' : 'my-1 w-full max-w-full [word-break:normal] [overflow-wrap:anywhere]'}>
                     {line}
                   </p>
                 ))}
@@ -199,7 +199,7 @@ export default function ContentBlock({
             // Loading state or fallback for when content is being rendered
             <div className="w-full max-w-full">
               {contentBlock.content.split('\n').map((line, j) => (
-                <p key={j} className={line.trim() === '' ? 'h-4' : '[word-break:normal] [overflow-wrap:anywhere]'}>
+                <p key={j} className={line.trim() === '' ? 'h-4 my-2' : 'my-2 w-full max-w-full [word-break:normal] [overflow-wrap:anywhere]'}>
                   {line}
                 </p>
               ))}


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Align spacing of streaming content blocks with static content blocks to ensure consistent UI.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
The problem was that streaming content used a fallback renderer with manual `<p>` tags, which lacked the margin classes (`my-2`) that the markdown renderer applied to static content. This led to inconsistent vertical spacing. The fix adds `my-2` to streaming text paragraphs and `my-1` to streaming thinking block paragraphs to match the static rendering.

---
<a href="https://cursor.com/background-agent?bcId=bc-c1a27d3a-824e-4436-b540-2b612f53038c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c1a27d3a-824e-4436-b540-2b612f53038c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>