### PR TITLE
Adjust branding card spacing and color

### DIFF
--- a/app/(logged-in)/projects/[id]/components/brand/color-card-skeleton.tsx
+++ b/app/(logged-in)/projects/[id]/components/brand/color-card-skeleton.tsx
@@ -5,11 +5,11 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function ColorCardSkeleton() {
   return (
-    <Card className="overflow-hidden group">
+    <Card className="overflow-hidden group pt-0 pb-3">
       {/* Color preview area skeleton - matches h-32 from ColorCard */}
       <Skeleton className="h-32 w-full rounded-none" />
       
-      <CardContent className="py-4 px-3">
+      <CardContent className="py-3 px-3">
         <div className="flex items-center justify-between">
           {/* Color name skeleton */}
           <Skeleton className="h-4 w-1/2" />

--- a/app/(logged-in)/projects/[id]/components/brand/color-card.tsx
+++ b/app/(logged-in)/projects/[id]/components/brand/color-card.tsx
@@ -162,7 +162,7 @@ export default function ColorCard({ colorVar, previewMode, onColorChange }: Colo
 
   return (
     <>
-      <Card className="overflow-hidden group">
+      <Card className="overflow-hidden group pt-0 pb-3">
         {/* Color preview with buttons on hover */}
         <div className="relative h-32 w-full">
           <div
@@ -200,7 +200,7 @@ export default function ColorCard({ colorVar, previewMode, onColorChange }: Colo
           </div>
         </div>
         
-        <CardContent className="py-4 px-3">
+        <CardContent className="py-3 px-3">
           <div className="flex items-center justify-between">
             <h3 className="font-medium text-sm" title={formatColorName(colorVar.name)}>
               {formatColorName(colorVar.name)}

--- a/app/(logged-in)/projects/[id]/components/brand/font-card-skeleton.tsx
+++ b/app/(logged-in)/projects/[id]/components/brand/font-card-skeleton.tsx
@@ -3,8 +3,8 @@ import { Skeleton } from '@/components/ui/skeleton';
 
 export default function FontCardSkeleton() {
   return (
-    <Card className="overflow-hidden">
-      <CardContent className="p-5">
+    <Card className="overflow-hidden pt-0 pb-3">
+      <CardContent className="p-4">
         <div className="flex justify-between items-start mb-4">
           <div className="space-y-2">
             <Skeleton className="h-5 w-32" />

--- a/app/(logged-in)/projects/[id]/components/brand/font-card.tsx
+++ b/app/(logged-in)/projects/[id]/components/brand/font-card.tsx
@@ -17,8 +17,8 @@ export default function FontCard({ font }: FontCardProps) {
       : font.provider;
   
   return (
-    <Card className="overflow-hidden">
-      <CardContent className="p-5">
+    <Card className="overflow-hidden pt-0 pb-3">
+      <CardContent className="p-4">
         <div className="flex justify-between items-start mb-4">
           <div>
             <h3 className="text-lg font-semibold">{font.name.replace('_', ' ')}</h3>


### PR DESCRIPTION
Adjust padding on branding color and font cards to extend color preview to top and reduce bottom spacing, without modifying the base Card component.

The user requested these changes to improve the visual appearance of the branding cards, making the color preview fill the top space and reducing overall card height, similar to how project cards were adjusted previously. This was achieved by overriding default padding classes directly on the `Card` and `CardContent` instances within the branding card components, ensuring the generic `Card` component remains untouched.

---
<a href="https://cursor.com/background-agent?bcId=bc-d40a6b14-9ac0-47ac-9d75-874f1844a325">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d40a6b14-9ac0-47ac-9d75-874f1844a325">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>