### PR TITLE
Reload preview after assistant stream

### DIFF
--- a/app/(logged-in)/projects/[id]/components/chat/chat-interface.tsx
+++ b/app/(logged-in)/projects/[id]/components/chat/chat-interface.tsx
@@ -135,19 +135,6 @@ export default function ChatInterface({
     // Save message for regeneration
     saveLastMessage(content, options);
 
-    // Trigger preview refresh if needed
-    if (content.toLowerCase().includes('update') ||
-        content.toLowerCase().includes('change') ||
-        content.toLowerCase().includes('modify') ||
-        options?.imageFile) {
-        const fileUpdatedEvent = new CustomEvent('file-updated', {
-          detail: { projectId }
-        });
-        window.dispatchEvent(fileUpdatedEvent);
-      }
-
-
-
     // Send the message
     sendMessage({ content, options });
   };

--- a/hooks/use-send-message.ts
+++ b/hooks/use-send-message.ts
@@ -550,6 +550,12 @@ export function useSendMessage(projectId: number) {
         // Invalidate and wait for the query to settle before clearing streaming state
         await queryClient.invalidateQueries({ queryKey: ['messages', projectId] });
 
+        // Trigger preview refresh after streaming completes to show reflected changes
+        const fileUpdatedEvent = new CustomEvent('file-updated', {
+          detail: { projectId },
+        });
+        window.dispatchEvent(fileUpdatedEvent);
+
         // Add small delay to ensure new data is rendered
         setTimeout(() => {
           setStreamingState({


### PR DESCRIPTION
<!-- One very short sentence on the WHAT and WHY of the PR. E.g. "Remove pathHash attribute because it is confirmed unused." or "Add DNS round robin to improve load distribution." -->
Move preview refresh to occur after assistant streaming completes to reflect changes.

<!-- OPTIONAL: If the WHY of the PR is not obvious, perhaps because it fixed a gnarly bug, explain it in a short paragraph here. E.g. "Commit a73bb98 introduced a bug where the class list was filtered to only work for MDC files, hence we partially revert it here." -->
Previously, the preview refreshed immediately upon sending a message, which was too early as the assistant's changes had not yet been applied or saved. This change ensures the preview reloads only after the streaming is complete and the backend has processed and saved the assistant's modifications.

---
<a href="https://cursor.com/background-agent?bcId=bc-7081df43-2069-4ac7-a8a7-80b1555f7ee5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7081df43-2069-4ac7-a8a7-80b1555f7ee5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>