### PR TITLE
Fix project store references in project components

### DIFF
--- a/app/(logged-in)/projects/components/project-card.tsx
+++ b/app/(logged-in)/projects/components/project-card.tsx
@@ -13,7 +13,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu';
-import { Project } from '@/lib/stores/projectStore';
+import type { Project } from '@/lib/db/schema';
 import DeleteProjectDialog from './delete-project-dialog';
 
 interface ProjectCardProps {


### PR DESCRIPTION
Update `project-card.tsx` to import `Project` type from the correct schema path, as `projectStore` no longer exists.

---
<a href="https://cursor.com/background-agent?bcId=bc-5027b0bd-1b60-4334-a188-2f5e3f6f5f89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-5027b0bd-1b60-4334-a188-2f5e3f6f5f89">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>