### PR TITLE
Investigate missing api connection display

### DIFF
--- a/hooks/use-github.ts
+++ b/hooks/use-github.ts
@@ -31,7 +31,8 @@ export function useGitHub() {
       const response = await fetch('/api/auth/github/status');
 
       if (response.ok) {
-        const data: GitHubStatusResponse = await response.json();
+        const responseData = await response.json();
+        const data: GitHubStatusResponse = responseData.data;
 
         if (data.connected && data.githubUsername) {
           setState(prev => ({


### PR DESCRIPTION
Fixes GitHub settings page not displaying data due to incorrect API response parsing.

The `useGitHub` hook was trying to access GitHub status fields directly from the API response, but the API returns the actual data nested under a `data` property (e.g., `{ data: { connected: true, ... } }`). This PR updates the hook to correctly access `responseData.data`.

---
<a href="https://cursor.com/background-agent?bcId=bc-60e1b4f9-9aef-436d-aec4-4eb995f729d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-60e1b4f9-9aef-436d-aec4-4eb995f729d0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

