### PR TITLE
Fix navbar pull request button in chat sessions

### DIFF
--- a/app/(logged-in)/projects/[id]/page.tsx
+++ b/app/(logged-in)/projects/[id]/page.tsx
@@ -9,6 +9,7 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { useChatMessages } from '@/hooks/use-chat-messages';
 import { useChatSessions } from '@/hooks/use-chat-sessions';
 import { usePreviewStatus, useStartPreview } from '@/hooks/use-preview-status';
+import { useCreatePullRequest } from '@/hooks/use-project-settings';
 import { useProjectUIState } from '@/hooks/use-project-ui-state';
 import { useProject } from '@/hooks/use-projects';
 import { cn } from '@/lib/utils';
@@ -141,6 +142,9 @@ export default function ProjectPage({ params }: ProjectPageProps) {
   const { data: messagesData, isLoading: isMessagesLoading } = useChatMessages(projectId, [], false);
   const { data: sessions = [] } = useChatSessions(projectId);
 
+  // Pull request functionality
+  const createPullRequestMutation = useCreatePullRequest(projectId);
+
     // UI state management
   const { currentView, setCurrentView, isChatCollapsed, toggleChatCollapsed } = useProjectUIState(project);
 
@@ -221,6 +225,22 @@ export default function ProjectPage({ params }: ProjectPageProps) {
     setShowSidebar(!showSidebar);
   };
 
+  // Handle creating pull request from active chat session
+  const handleCreatePullRequest = () => {
+    if (!activeChatSessionId || !currentSession?.sessionId) {
+      console.error('No active chat session for pull request creation');
+      return;
+    }
+
+    createPullRequestMutation.mutate({
+      sessionId: currentSession.sessionId,
+      data: {
+        title: `Updates from chat session: ${currentSession.title}`,
+        description: `Automated changes from Kosuke chat session: ${currentSession.title}\n\nSession ID: ${currentSession.sessionId}`,
+      },
+    });
+  };
+
   return (
     <div className="flex flex-col h-screen w-full">
       <Navbar
@@ -234,6 +254,8 @@ export default function ProjectPage({ params }: ProjectPageProps) {
           onToggleChat: toggleChatCollapsed,
           showSidebar: showSidebar,
           onToggleSidebar: toggleSidebar,
+          activeChatSessionId: activeChatSessionId,
+          onCreatePullRequest: handleCreatePullRequest,
         }}
       />
             <div className={cn('flex h-[calc(100vh-3.5rem)] w-full overflow-hidden')}>

--- a/app/api/projects/[id]/chat-sessions/[sessionId]/pull-request/route.ts
+++ b/app/api/projects/[id]/chat-sessions/[sessionId]/pull-request/route.ts
@@ -149,6 +149,7 @@ export async function POST(
       }
 
       // Create pull request
+      const prTitle = title || `Updates from chat session: ${session.title}`;
       const { data: pullRequest } = await github.rest.pulls.create({
         owner: project.githubOwner,
         repo: project.githubRepoName,


### PR DESCRIPTION
Enable and show the Pull Request button in the navbar for active chat sessions, allowing users to create PRs from their session branches.

---
<a href="https://cursor.com/background-agent?bcId=bc-d55a9a58-0a08-40ac-ac5e-00e562fd2ca7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d55a9a58-0a08-40ac-ac5e-00e562fd2ca7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

