### PR TITLE
Add production tab with deployment warning

### DIFF
--- a/app/(logged-in)/projects/[id]/components/settings/production-settings.tsx
+++ b/app/(logged-in)/projects/[id]/components/settings/production-settings.tsx
@@ -1,0 +1,37 @@
+'use client';
+
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { AlertTriangle, ExternalLink } from 'lucide-react';
+
+interface ProductionSettingsProps {
+  projectId: number;
+}
+
+export function ProductionSettings({ projectId }: ProductionSettingsProps) {
+  return (
+    <div className="space-y-6">
+      <div>
+        <h3 className="text-xl font-medium">Production</h3>
+        <p className="text-muted-foreground mt-2">
+          Production deployment guidelines and best practices
+        </p>
+      </div>
+
+      <Alert className="bg-amber-50 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800">
+        <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
+        <AlertDescription className="text-amber-700 dark:text-amber-300">
+          Don't use review apps in production. Follow the instructions below in this documentation for a production deployment:{' '}
+          <a 
+            href="https://github.com/filopedraz/kosuke-template#-deployment--production"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="underline hover:no-underline inline-flex items-center gap-1"
+          >
+            https://github.com/filopedraz/kosuke-template#-deployment--production
+            <ExternalLink className="h-3 w-3" />
+          </a>
+        </AlertDescription>
+      </Alert>
+    </div>
+  );
+}

--- a/app/(logged-in)/projects/[id]/components/settings/production-settings.tsx
+++ b/app/(logged-in)/projects/[id]/components/settings/production-settings.tsx
@@ -1,13 +1,9 @@
 'use client';
 
 import { Alert, AlertDescription } from '@/components/ui/alert';
-import { AlertTriangle, ExternalLink } from 'lucide-react';
+import { AlertTriangle } from 'lucide-react';
 
-interface ProductionSettingsProps {
-  projectId: number;
-}
-
-export function ProductionSettings({ projectId }: ProductionSettingsProps) {
+export function ProductionSettings() {
   return (
     <div className="space-y-6">
       <div>
@@ -17,19 +13,20 @@ export function ProductionSettings({ projectId }: ProductionSettingsProps) {
         </p>
       </div>
 
-      <Alert className="bg-amber-50 border-amber-200 dark:bg-amber-950/20 dark:border-amber-800">
-        <AlertTriangle className="h-4 w-4 text-amber-600 dark:text-amber-400" />
-        <AlertDescription className="text-amber-700 dark:text-amber-300">
-          Don't use review apps in production. Follow the instructions below in this documentation for a production deployment:{' '}
-          <a 
-            href="https://github.com/filopedraz/kosuke-template#-deployment--production"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="underline hover:no-underline inline-flex items-center gap-1"
-          >
+      <Alert variant="destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <AlertDescription>
+          Do not use review apps in production. See the production deployment guide at: {' '}
+          <span className="inline-flex items-center gap-1 whitespace-nowrap">
+            <a
+              href="https://github.com/filopedraz/kosuke-template#-deployment--production"
+              target="_blank"
+              rel="noopener noreferrer"
+              className="underline hover:no-underline"
+            >
             https://github.com/filopedraz/kosuke-template#-deployment--production
-            <ExternalLink className="h-3 w-3" />
-          </a>
+            </a>
+          </span>
         </AlertDescription>
       </Alert>
     </div>

--- a/app/(logged-in)/projects/[id]/components/settings/settings-tab.tsx
+++ b/app/(logged-in)/projects/[id]/components/settings/settings-tab.tsx
@@ -42,7 +42,7 @@ export function SettingsTab({ projectId }: SettingsTabProps) {
         </TabsContent>
 
         <TabsContent value="production" className="space-y-6 pt-6 pb-12">
-          <ProductionSettings projectId={projectId} />
+          <ProductionSettings />
         </TabsContent>
       </Tabs>
     </div>

--- a/app/(logged-in)/projects/[id]/components/settings/settings-tab.tsx
+++ b/app/(logged-in)/projects/[id]/components/settings/settings-tab.tsx
@@ -4,6 +4,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { Settings } from 'lucide-react';
 import DefaultBranchSettings from './default-branch-settings';
 import { EnvironmentVariables } from './environment-variables';
+import { ProductionSettings } from './production-settings';
 import { SubdomainDisplay } from './subdomain-display';
 
 interface SettingsTabProps {
@@ -25,6 +26,7 @@ export function SettingsTab({ projectId }: SettingsTabProps) {
           <TabsTrigger value="environment">Environment Variables</TabsTrigger>
           <TabsTrigger value="branch">Default Branch</TabsTrigger>
           <TabsTrigger value="subdomains">Preview URLs</TabsTrigger>
+          <TabsTrigger value="production">Production</TabsTrigger>
         </TabsList>
 
         <TabsContent value="environment" className="space-y-6 pt-6 pb-12">
@@ -37,6 +39,10 @@ export function SettingsTab({ projectId }: SettingsTabProps) {
 
         <TabsContent value="subdomains" className="space-y-6 pt-6 pb-12">
           <SubdomainDisplay projectId={projectId} />
+        </TabsContent>
+
+        <TabsContent value="production" className="space-y-6 pt-6 pb-12">
+          <ProductionSettings projectId={projectId} />
         </TabsContent>
       </Tabs>
     </div>


### PR DESCRIPTION
Add a Production tab to project settings with a warning banner and a link to production deployment documentation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d15855c2-1481-4675-8461-4f905cbbb5ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d15855c2-1481-4675-8461-4f905cbbb5ea">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

