### PR TITLE
Handle project creation on enter

### DIFF
--- a/app/(logged-in)/projects/components/project-creation-modal.tsx
+++ b/app/(logged-in)/projects/components/project-creation-modal.tsx
@@ -127,11 +127,29 @@ export default function ProjectCreationModal({
     return activeTab === 'create' ? 'Create Project' : 'Import Project';
   };
 
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    // Only trigger on Enter key
+    if (e.key !== 'Enter') return;
+    
+    // Don't trigger if focus is on textarea (description field)
+    if (e.target instanceof HTMLTextAreaElement) return;
+    
+    // Don't trigger if form cannot be submitted
+    if (!canSubmit() || isCreating) return;
+    
+    // Prevent default form submission behavior
+    e.preventDefault();
+    
+    // Trigger project creation
+    handleCreateProject();
+  };
+
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
       <DialogContent
         className="p-0 overflow-hidden border border-border bg-card shadow-lg rounded-md"
         style={{ maxWidth: '512px' }}
+        onKeyDown={handleKeyDown}
       >
         <DialogTitle className="sr-only">
           {activeTab === 'create' ? 'Create New Project' : 'Import from GitHub'}


### PR DESCRIPTION
Add keyboard handling to the project creation modal to allow creating/importing projects on Enter press, excluding the description textarea.

---
<a href="https://cursor.com/background-agent?bcId=bc-1dec6faa-bea9-4119-abdb-d67dd330fc7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1dec6faa-bea9-4119-abdb-d67dd330fc7e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

