### PR TITLE
Debug blank screen and add testflight release command

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -7,7 +7,7 @@ import * as SecureStore from 'expo-secure-store';
 import * as SplashScreen from 'expo-splash-screen';
 import { StatusBar } from 'expo-status-bar';
 import React, { useEffect } from 'react';
-import { View } from 'react-native';
+import { View, Text } from 'react-native';
 import 'react-native-reanimated';
 import { SafeAreaProvider } from 'react-native-safe-area-context';
 
@@ -75,7 +75,21 @@ export default function RootLayout() {
     SpaceMono: '../assets/fonts/SpaceMono-Regular.ttf',
   });
 
-  const publishableKey = Constants.expoConfig?.extra?.CLERK_PUBLISHABLE_KEY as string | undefined;
+  const publishableKey =
+    process.env.EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY ??
+    (Constants.expoConfig?.extra?.CLERK_PUBLISHABLE_KEY as string | undefined);
+
+  if (!publishableKey) {
+    return (
+      <SafeAreaProvider>
+        <View style={{ flex: 1, alignItems: 'center', justifyContent: 'center', padding: 24 }}>
+          <Text style={{ textAlign: 'center' }}>
+            Missing Clerk publishable key. Set EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY or extra.CLERK_PUBLISHABLE_KEY.
+          </Text>
+        </View>
+      </SafeAreaProvider>
+    );
+  }
 
   return (
     <SafeAreaProvider>

--- a/mobile/eas.json
+++ b/mobile/eas.json
@@ -10,6 +10,7 @@
       "env": {
         "API_BASE_URL": "http://localhost:3000/api",
         "CLERK_PUBLISHABLE_KEY": "pk_test_cHJpbWFyeS1kb25rZXktNDkuY2xlcmsuYWNjb3VudHMuZGV2JA",
+        "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY": "pk_test_cHJpbWFyeS1kb25rZXktNDkuY2xlcmsuYWNjb3VudHMuZGV2JA",
         "SENTRY_DSN": "https://9d63971f39fa9f4799e0a75224c46d05@o4508021471576064.ingest.de.sentry.io/4509820516761680"
       }
     },
@@ -18,6 +19,7 @@
       "env": {
         "API_BASE_URL": "https://kosuke.ai/api",
         "CLERK_PUBLISHABLE_KEY": "pk_live_Y2xlcmsua29zdWtlLmFpJA",
+        "EXPO_PUBLIC_CLERK_PUBLISHABLE_KEY": "pk_live_Y2xlcmsua29zdWtlLmFpJA",
         "SENTRY_DSN": "https://9d63971f39fa9f4799e0a75224c46d05@o4508021471576064.ingest.de.sentry.io/4509820516761680"
       }
     }

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -12,7 +12,8 @@
     "clean:cache": "rm -rf .expo && rm -rf ios/ && xcrun simctl shutdown all && xcrun simctl erase all",
     "web": "expo start --web",
     "lint": "expo lint",
-    "ios": "expo run:ios"
+    "ios": "expo run:ios",
+    "ios:release:testflight": "APP_VARIANT=production npx eas build --platform ios --profile production --non-interactive --auto-submit"
   },
   "dependencies": {
     "@clerk/clerk-expo": "^2.14.14",


### PR DESCRIPTION
Add `ios:release:testflight` script to `package.json` to enable direct TestFlight releases from local CLI.

---
[Slack Thread](https://kosuke-wcp4140.slack.com/archives/C09693CVA0J/p1755055074959699?thread_ts=1755055074.959699&cid=C09693CVA0J)

<a href="https://cursor.com/background-agent?bcId=bc-f0a18440-39fd-46f1-8f62-5a5c1efaa383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f0a18440-39fd-46f1-8f62-5a5c1efaa383">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

